### PR TITLE
Test scripts robustness

### DIFF
--- a/testing/run-tests.sh
+++ b/testing/run-tests.sh
@@ -2,20 +2,26 @@
 
 # Setup some safe shell options
 set -eu -o pipefail
+shopt -s nullglob
+
+if [ ! -d ../examples ]; then
+    echo "../examples not found.  Please run run-tests.sh from the 'testing' directory." >&2
+    exit 1
+fi
 
 # No arguments
 if [ $# -eq 0 ]
 then
 
 	# Set testCases
-	testCases=`ls -d */`
+	testCases=$(ls -d -- */)
 
 # One argument
 elif [ $# -eq 1 ]
 then
 
 	# Check if it is a real case
-	if [ ! -d $1 ]; then
+	if [ ! -d "$1" ]; then
 		printf "\nCase name is not a real example case...exiting\n\n"
 		exit
 	fi
@@ -38,41 +44,41 @@ do
 	case=${d%/}
 
 	# Print header
-	printf "\nRunning $case test!\n\n"
+	printf "\nRunning %s test!\n\n" "$case"
 
 	# Check if there is reference data
-	if [ ! -d $case/RefData ]; then
-		printf "\nThere is no reference data for $case case...exiting\n\n"
+	if [ ! -d "$case"/RefData ]; then
+		printf "\nThere is no reference data for %s case...exiting\n\n" "$case"
 		exit
 	fi
 
 	# Clean the directory first
-	rm -rf $case/LIFE $case/Results $case/$case.diff
+	rm -rf "$case"/LIFE "$case"/Results "$case/$case.diff"
 
 	# Copy params.h from RefData into src folder
-	cp $case/RefData/params.h ../inc/params.h
+	cp "$case"/RefData/params.h ../inc/params.h
 
 	# Build LIFE
 	(cd .. && make clean && make -j 8)
 
 	# Copy case to directory
-	cp ../LIFE $case/.
+	cp ../LIFE "$case/."
 
 	# Check if there a geometry.config file
-	if [ -d $case/RefData/input ]; then
-		cp -r $case/RefData/input $case/.
+	if [ -d "$case"/RefData/input ]; then
+		cp -r "$case"/RefData/input "$case"/.
 	fi
 
 	# Run the case
-	(cd $case && ./LIFE)
+	(cd "$case" && ./LIFE)
 
 	# If TurekHron case then run again to test restart feature
-	if [ $case == "TurekHron" ]; then
-		(cd $case && ./LIFE)
+	if [ "$case" == "TurekHron" ]; then
+		(cd "$case" && ./LIFE)
 	fi
 
 	# Print finish
-	printf "Finished running $case test!\n\n"
+	printf "Finished running %s test!\n\n" "$case"
 done
 
 # Print header
@@ -94,24 +100,24 @@ do
 	case=${d%/}
 
 	# Check if results exist
-	if [ -d $case/Results ]; then
+	if [ -d "$case"/Results ]; then
 
 		# Run diff and output to file
-		if diff -r $case/Results $case/RefData/Results --exclude=Log.out &> $case/$case.diff; then
-			printf "${green}PASS${normal} -> $case\n\n"
+		if diff -r "$case"/Results "$case"/RefData/Results --exclude=Log.out &> "$case/$case.diff"; then
+			printf "%s\n\n" "${green}PASS${normal} -> $case"
 		else
-			printf "${red}FAIL${normal} -> $case\n\n"
+			printf "%s\n\n" "${red}FAIL${normal} -> $case"
 			nFails=$((nFails+1))
 		fi
 	else
-		printf "${red}MISSING${normal} -> $case\n\n"
+		printf "%s\n\n" "${red}MISSING${normal} -> $case"
 		nFails=$((nFails+1))
 	fi
 done
 
 # Check if fails is more than zero times
 if [ $nFails -eq 0 ]; then
-	printf "\n${green}PASSED ALL TESTS!${normal}\n\n"
+	printf "\n%s\n\n" "${green}PASSED ALL TESTS!${normal}"
 else
-	printf "\n${red}FAILED SOME TESTS!${normal}\n\n"
+	printf "\n%s\n\n" "${red}FAILED SOME TESTS!${normal}"
 fi

--- a/testing/store-ref-data.sh
+++ b/testing/store-ref-data.sh
@@ -2,6 +2,12 @@
 
 # Setup some safe shell options
 set -eu -o pipefail
+shopt -s nullglob
+
+if [ ! -d ../examples ]; then
+    echo "../examples not found.  Please run store-ref-data.sh from the 'testing' directory." >&2
+    exit 1
+fi
 
 # Find all example cases
 for d in ../examples/*/
@@ -14,14 +20,14 @@ do
 	caseName=${casePath##*/}
 
 	# Print header
-	printf "\nStoring new $caseName RefData!\n\n"
+	printf "\nStoring new %s RefData!\n\n" "$caseName"
 
 	# Clean/create the case directory
-	rm -rf $caseName
-	mkdir $caseName
+	rm -rf "$caseName"
+	mkdir "$caseName"
 
 	# Copy params.h from examples into src folder
-	cp $casePath/params.h ../inc/params.h
+	cp "$casePath"/params.h ../inc/params.h
 
 	# Modifiy the write out frequencies for testing
 	sed -i "/const int nSteps/c\const int nSteps = 500;" ../inc/params.h
@@ -33,25 +39,25 @@ do
 	(cd .. && make clean && make -j 8)
 
 	# Create ref directory
-	mkdir $caseName/RefData
+	mkdir "$caseName"/RefData
 
 	# Copy case to RefData
-	cp ../LIFE $caseName/RefData/.
-	cp ../inc/params.h $caseName/RefData/.
+	cp ../LIFE "$caseName"/RefData/.
+	cp ../inc/params.h "$caseName"/RefData/.
 
 	# Check if there a geometry.config file
-	if [ -d $casePath/input ]; then
-		cp -r $casePath/input $caseName/RefData/.
+	if [ -d "$casePath"/input ]; then
+		cp -r "$casePath"/input "$caseName"/RefData/.
 	fi
 
 	# Run the case
-	(cd $caseName/RefData && ./LIFE)
+	(cd "$caseName"/RefData && ./LIFE)
 
 	# If TurekHron case then run again to test restart feature
-	if [ $caseName == "TurekHron" ]; then
-		(cd $caseName/RefData && ./LIFE)
+	if [ "$caseName" == "TurekHron" ]; then
+		(cd "$caseName"/RefData && ./LIFE)
 	fi
 
 	# Print finish
-	printf "Finished storing new $caseName RefData!\n\n"
+	printf "Finished storing new %s RefData!\n\n" "$caseName"
 done


### PR DESCRIPTION
**store-ref-data.sh: Ensure run from testing directory and make more robust**
    
- Add `shopt -s nullglob` to make sure that `../examples/*`
  expands to nothing rather than to itself when there are no matches.
  Otherwise, running in the LIFE directory leads to `rm -rf *`!
- Add an explicit check that the script is run in the right directory, and
  give a helpful error message if it isn't.
- Quote variable expansions.  This ensures that the script works if there
  are spaces or shell metacharacters in variables. It would also have
  stopped the "*" being interpreted as a wildcard.
- Remove variable expansions from printf format string.  If the variables
  have printf format characters (e.g. %) in them, it would lead to unintended
  results.
    
Mostly, this is just defensive bash programming.  Issues like these can
be found easily using `shellcheck`, either on the command line, or at
https://www.shellcheck.net.  Integrating a shell checker in your editor
is also helpful (I use flycheck for emacs).
    
Or just use python :)

**run-tests.sh: Add check for correct directory and make more robust**
    
Now passes shellcheck.

--

I have tested that storing the reference data and running the tests works after this change.
