### PR TITLE
Support running tests in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,15 @@
+pipeline {
+    agent { "ultron" }
+    stages {
+        stage('store') {
+            steps {
+                sh 'set -e; if [ ! -r testing/.stored ]; then cd testing; ./store-ref-data.sh; touch .stored; fi'
+            }
+        }
+        stage('test') {
+            steps {
+                sh 'set -e; cd testing; ./run-tests.sh'
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { any }
+    agent any
     stages {
         stage('store') {
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent any
+    agent { node { label 'linux' } }
     stages {
         stage('store') {
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
         }
         stage('test') {
             steps {
-                sh 'set -e; cd testing; ./run-tests.sh'
+                sh 'set -e; cd testing; TERM=dumb ./run-tests.sh'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { "ultron" }
+    agent { any }
     stages {
         stage('store') {
             steps {

--- a/testing/run-tests.sh
+++ b/testing/run-tests.sh
@@ -79,9 +79,15 @@ done
 printf "\n\n\nChecking against reference data...\n\n"
 
 # Set colors
-normal=$(tput sgr0)
-red=$(tput setaf 1)
-green=$(tput setaf 2)
+if [ -t 1 ]; then
+    normal=$(tput sgr0)
+    red=$(tput setaf 1)
+    green=$(tput setaf 2)
+else
+    normal=""
+    red=""
+    green=""
+fi
 
 # Number of fails
 nFails=0


### PR DESCRIPTION
This PR introduces a "Jenkinsfile" to the repository.  This file is picked up by the Jenkins continuous integration test system and describes how to run the tests.  This allows an installation of Jenkins to be connected to GitHub, detect changes, and run the tests automatically.

It was also necessary to modify run-tests.sh to only use colours if running in a terminal, otherwise the script would crash when not running in a terminal.
